### PR TITLE
Fix:Correção do comportamento de tela vazia (Empty State) nos filtros de receitas

### DIFF
--- a/receitas/src/main/java/br/com/weg/receitas/application/receita/ReceitaServiceImpl.java
+++ b/receitas/src/main/java/br/com/weg/receitas/application/receita/ReceitaServiceImpl.java
@@ -125,9 +125,6 @@ public class ReceitaServiceImpl implements ReceitaService{
         }
         List<Receita> receitas = receitaRepository.findByTempoPreparoBetween(tempoMin,tempoMax);
 
-        if(receitas.isEmpty()){
-            throw new RuntimeException("Nenhuma receita esta entre esse espaço de tempo");
-        }
         return receitaMapper.toDTOList(receitas);
 
 


### PR DESCRIPTION
💡 Contexto
Foi identificado um bug no aplicativo onde, ao utilizar o filtro de "Tempo de Preparo" para um intervalo sem receitas cadastradas, a tela não era limpa. O aplicativo continuava exibindo os dados da busca anterior. Este PR resolve a inconsistência na comunicação entre a API e o App, padronizando o retorno de listas vazias.

🛠️ Alterações Realizadas
No Back-end (Spring Boot):

Arquivo modificado: ReceitaServiceImpl.java

O que mudou: Removida a RuntimeException que era lançada dentro do método findPorTempoPreparo quando a lista de receitas estava vazia.

Motivo: O lançamento dessa exceção gerava um erro 500 Internal Server Error. No padrão REST, uma busca que não encontra resultados não é um erro do servidor, mas sim um sucesso que retorna um array vazio. Agora, o método retorna um array vazio [] (HTTP 200 OK), mantendo o mesmo padrão do filtro de porções.

No Front-end (Android/Jetpack Compose):

Arquivo modificado: ReceitaViewModel.kt

O que mudou: Adicionada a instrução listaReceitas = emptyList() dentro dos blocos else e catch das funções filtrarReceitasPorTempo e filtrarPorPorcoes.

Motivo: Isso garante que o estado da interface (listaReceitas) seja limpo caso a API retorne um erro (como um 404) ou ocorra uma falha de conexão. Com a lista vazia, o Jetpack Compose desenha corretamente a tela de "Empty State" (Nenhum prato encontrado).

🧪 Como Testar
Suba a API localmente ou faça o deploy das alterações no Render.

Abra o aplicativo Android e navegue até a tela "Suas Receitas".

Clique no botão de "Filtro".

Selecione a opção "Tempo de Preparo" e escolha um intervalo onde sabidamente não há receitas (ex: 5-10 min).

Resultado esperado: A tela deve limpar a lista atual e mostrar a mensagem/ícone de que nenhuma receita foi encontrada.

Repita o processo desligando a internet do emulador/celular para testar o bloco catch. A lista também deve ser limpa e exibir a mensagem de erro.